### PR TITLE
add doc and test webpage for rosbridge server

### DIFF
--- a/rosbridge-server/README.md
+++ b/rosbridge-server/README.md
@@ -1,0 +1,30 @@
+# rosbridge-server
+
+We use a third-party package called [rosbridge_server](http://wiki.ros.org/rosbridge_server) to allow interaction with ROS topics via websocket (which is a common streaming protocol for web services).
+
+## Steps to run the server
+
+You will need ROS installed in your system before doing the following steps. If you have not done so, refer to [ROS documentation](http://wiki.ros.org/ROS/Tutorials).
+
+1. If you don't have rosbridge server installed (i.e. `rospack find rosbridge_server` returns nothing), install with:
+
+    ```
+    sudo apt install ros-<rosdistro>-rosbridge-suite
+    ```
+
+2. Start rosbridge server with:
+
+    ```
+    roslaunch rosbridge_server rosbridge_websocket.launch
+    ```
+
+    By default it listens on port `9090` for websocket connections. It also registers a node called `rosbridge_websocket` which you can verify by `rosnode list`.
+
+3. Testing with a browser and Autoronto rosbag:
+
+    ```
+    # run the Autoronto rosbag:
+    rosbag play _2019-01-23-13-28-36_imu_baselink-007.bag
+    ```
+
+    Then open `websocket-client-test.html` in a browser. You should be able to see data coming from the topic `/navsat/fix`.

--- a/rosbridge-server/websocket-client-test.html
+++ b/rosbridge-server/websocket-client-test.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+
+<script type="text/javascript" src="http://static.robotwebtools.org/EventEmitter2/current/eventemitter2.min.js"></script>
+<script type="text/javascript" src="http://static.robotwebtools.org/roslibjs/current/roslib.min.js"></script>
+
+<script type="text/javascript" type="text/javascript">
+  // Connecting to ROS
+  // -----------------
+
+  var ros = new ROSLIB.Ros({
+    url : 'ws://localhost:9090'
+  });
+
+  ros.on('connection', function() {
+    console.log('Connected to websocket server.');
+  });
+
+  ros.on('error', function(error) {
+    console.log('Error connecting to websocket server: ', error);
+  });
+
+  ros.on('close', function() {
+    console.log('Connection to websocket server closed.');
+  });
+
+  // Publishing a Topic
+  // ------------------
+/*
+  var cmdVel = new ROSLIB.Topic({
+    ros : ros,
+    name : '/cmd_vel',
+    messageType : 'geometry_msgs/Twist'
+  });
+
+  var twist = new ROSLIB.Message({
+    linear : {
+      x : 0.1,
+      y : 0.2,
+      z : 0.3
+    },
+    angular : {
+      x : -0.1,
+      y : -0.2,
+      z : -0.3
+    }
+  });
+  cmdVel.publish(twist);
+*/
+  // Subscribing to a Topic
+  // ----------------------
+
+  var listener = new ROSLIB.Topic({
+    ros : ros,
+    name : '/navsat/fix'
+    //messageType : 'geometry_msgs/Twist'
+  });
+
+  listener.subscribe(function(message) {
+    var msgNew = 'Received message on ' + listener.name + JSON.stringify(message, null, 2) + "\n";
+    document.getElementById("message-display").innerHTML = msgNew;
+    //listener.unsubscribe();
+  });
+
+  // Calling a service
+  // -----------------
+/*
+  var addTwoIntsClient = new ROSLIB.Service({
+    ros : ros,
+    name : '/add_two_ints',
+    serviceType : 'rospy_tutorials/AddTwoInts'
+  });
+
+  var request = new ROSLIB.ServiceRequest({
+    a : 1,
+    b : 2
+  });
+
+  addTwoIntsClient.callService(request, function(result) {
+    console.log('Result for service call on '
+      + addTwoIntsClient.name
+      + ': '
+      + result.sum);
+  });
+
+  // Getting and setting a param value
+  // ---------------------------------
+
+  ros.getParams(function(params) {
+    console.log(params);
+  });
+
+  var maxVelX = new ROSLIB.Param({
+    ros : ros,
+    name : 'max_vel_y'
+  });
+
+  maxVelX.set(0.8);
+  maxVelX.get(function(value) {
+    console.log('MAX VAL: ' + value);
+  });
+*/
+</script>
+</head>
+
+<body>
+  <h1>Rosbridge websocket client</h1>
+  <p>Establishing connection with Rosbridge server...</p>
+  <pre id="message-display">
+  </pre>
+</body>
+</html>


### PR DESCRIPTION
Document steps to start rosbridge server and run a test client in a browser.